### PR TITLE
Fix tests for python3.

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -121,7 +121,7 @@ that define the shape.
         self._marker_function()
 
     def __nonzero__(self):
-        return len(self._path.vertices)
+        return bool(len(self._path.vertices))
 
     def is_filled(self):
         return self._filled


### PR DESCRIPTION
I tested the python3 branch on both python3 and 2. 
I see around 170 errors when running the test suite in python3
They are all of `TypeError: __bool__ should return bool, returned int`

This is fixed by changing `__nozero__` to return bool. 2to3 converts this to `__bool__` that must return a bool not an integer. I don't know if this has any negative side effects on python2 **nonzero** but 
it does not change the number of tests passing on python2.

In addition I see two new failures on both python3 and 2 using this branch. 'Tight_layout5' and 
'interp_nearest_vs_none' both fail in the svg version because the none interpolation images are 
updown inverted. This does not seem to happen on master. (I also see a failure on master using tight_layout5 but the difference is smaller and the image is not inverted) 
