### PR TITLE
Py3 update texmanager

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -259,7 +259,7 @@ WARNING: found a TeX cache dir in the deprecated location "%s".
                 fh.write(s.encode('utf8'))
             else:
                 try:
-                    fh.write(s)
+                    fh.write(s.encode('ascii'))
                 except UnicodeEncodeError as err:
                     mpl.verbose.report("You are using unicode and latex, but have "
                                 "not enabled the matplotlib 'text.latex.unicode' "
@@ -322,7 +322,7 @@ WARNING: found a TeX cache dir in the deprecated location "%s".
                 fh.write(s.encode('utf8'))
             else:
                 try:
-                    fh.write(s)
+                    fh.write(s.encode('ascii'))
                 except UnicodeEncodeError as err:
                     mpl.verbose.report("You are using unicode and latex, but have "
                                 "not enabled the matplotlib 'text.latex.unicode' "


### PR DESCRIPTION
I have encountered an exception raised when usetex=True.

```
  File "/home/jjlee/.virtualenvs/dev32/lib/python3.2/site-packages/matplotlib/texmanager.py", line 325, in make_tex_preview
    fh.write(s)
TypeError: 'str' does not support the buffer interface
```

This happens when tex string is not cached in ~/.matplotlib/tex.cache.
Replacing fh.write(s) to fh.write(s.encode("ascii") seem to fix the problem but I'm not quite sure if this is an appropriate approach.  
