### PR TITLE
Interactive svg

### DIFF
--- a/examples/user_interfaces/svg_tooltip.py
+++ b/examples/user_interfaces/svg_tooltip.py
@@ -1,0 +1,125 @@
+"""
+SVG tooltip example
+===================
+
+This example shows how to create a tooltip that will show up when 
+hovering over a matplotlib patch. 
+
+Although it is possible to create the tooltip from CSS or javascript, 
+here we create it in matplotlib and simply toggle its visibility on 
+when hovering over the patch. This approach provides total control over 
+the tooltip placement and appearance, at the expense of more code up
+front. 
+
+The alternative approach would be to put the tooltip content in `title` 
+atttributes of SVG objects. Then, using an existing js/CSS library, it 
+would be relatively straightforward to create the tooltip in the 
+browser. The content would be dictated by the `title` attribute, and 
+the appearance by the CSS. 
+
+
+:author: David Huard
+"""
+
+
+import matplotlib.pyplot as plt
+import xml.etree.ElementTree as ET
+from StringIO import StringIO
+
+ET.register_namespace("","http://www.w3.org/2000/svg")
+
+fig = plt.figure()
+ax = fig.add_subplot(111)
+
+# Create patches to which tooltips will be assigned.
+circle = plt.Circle((0,0), 5, fc='blue')
+rect = plt.Rectangle((-5, 10), 10, 5, fc='green')
+
+ax.add_patch(circle)
+ax.add_patch(rect)
+
+# Create the tooltips
+circle_tip = ax.annotate('This is a blue circle.', 
+            xy=(0,0), 
+            xytext=(30,-30), 
+            textcoords='offset points', 
+            color='w', 
+            ha='left', 
+            bbox=dict(boxstyle='round,pad=.5', fc=(.1,.1,.1,.92), ec=(1.,1.,1.), lw=1, zorder=1),
+            )
+            
+rect_tip = ax.annotate('This is a green rectangle.', 
+            xy=(-5,10), 
+            xytext=(30,40), 
+            textcoords='offset points', 
+            color='w', 
+            ha='left', 
+            bbox=dict(boxstyle='round,pad=.5', fc=(.1,.1,.1,.92), ec=(1.,1.,1.), lw=1, zorder=1),
+            )
+            
+
+# Set id for the patches    
+for i, t in enumerate(ax.patches):
+    t.set_gid('patch_%d'%i)
+
+# Set id for the annotations
+for i, t in enumerate(ax.texts):
+    t.set_gid('tooltip_%d'%i)
+
+
+# Save the figure in a fake file object
+ax.set_xlim(-30, 30)
+ax.set_ylim(-30, 30)
+ax.set_aspect('equal')
+
+f = StringIO()
+plt.savefig(f, format="svg")
+
+# --- Add interactivity ---
+
+# Create XML tree from the SVG file.
+tree, xmlid = ET.XMLID(f.getvalue())
+tree.set('onload', 'init(evt)')
+
+# Hide the tooltips
+for i, t in enumerate(ax.texts):
+    el = xmlid['tooltip_%d'%i]
+    el.set('visibility', 'hidden')
+
+# Assign onmouseover and onmouseout callbacks to patches.        
+for i, t in enumerate(ax.patches):
+    el = xmlid['patch_%d'%i]
+    el.set('onmouseover', "ShowTooltip(this)")
+    el.set('onmouseout', "HideTooltip(this)")
+
+# This is the script defining the ShowTooltip and HideTooltip functions.
+script = """
+    <script type="text/ecmascript">
+    <![CDATA[
+    
+    function init(evt) {
+        if ( window.svgDocument == null ) {
+            svgDocument = evt.target.ownerDocument;
+            }
+        }
+        
+    function ShowTooltip(obj) {
+        var cur = obj.id.slice(-1);
+        
+        var tip = svgDocument.getElementById('tooltip_' + cur);
+        tip.setAttribute('visibility',"visible")
+        }
+        
+    function HideTooltip(obj) {
+        var cur = obj.id.slice(-1);
+        var tip = svgDocument.getElementById('tooltip_' + cur);
+        tip.setAttribute('visibility',"hidden")
+        }
+        
+    ]]>
+    </script>
+    """
+
+# Insert the script at the top of the file and save it.
+tree.insert(0, ET.XML(script))
+ET.ElementTree(tree).write('svg_tooltip.svg')

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -649,6 +649,7 @@ class GraphicsContextBase:
         self._rgb = (0.0, 0.0, 0.0)
         self._hatch = None
         self._url = None
+        self._gid = None
         self._snap = None
 
     def copy_properties(self, gc):
@@ -665,6 +666,7 @@ class GraphicsContextBase:
         self._rgb = gc._rgb
         self._hatch = gc._hatch
         self._url = gc._url
+        self._gid = gc._gid
         self._snap = gc._snap
 
     def restore(self):
@@ -753,6 +755,12 @@ class GraphicsContextBase:
         """
         return self._url
 
+    def get_gid(self):
+        """
+        Return the object identifier if one is set, None otherwise.
+        """
+        return self._gid
+        
     def get_snap(self):
         """
         returns the snap setting which may be:
@@ -875,6 +883,12 @@ class GraphicsContextBase:
         """
         self._url = url
 
+    def set_gid(self, id):
+        """
+        Sets the id.
+        """
+        self._gid = id
+        
     def set_snap(self, snap):
         """
         Sets the snap setting which may be:

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -735,7 +735,7 @@ class RendererSVG(RendererBase):
             im.resize(numcols, numrows)
 
         h,w = im.get_size_out()
-
+        oid = getattr(im, '_gid', None)
         url = getattr(im, '_url', None)
         if url is not None:
             self.writer.start('a', attrib={'xlink:href': url})
@@ -745,6 +745,7 @@ class RendererSVG(RendererBase):
             rows, cols, buffer = im.as_rgba_str()
             _png.write_png(buffer, cols, rows, stringio)
             im.flipud_out()
+            oid = oid or self._make_id('image', stringio)
             attrib['xlink:href'] = ("data:image/png;base64,\n" +
                                     base64.encodestring(stringio.getvalue()))
         else:
@@ -755,8 +756,11 @@ class RendererSVG(RendererBase):
             rows, cols, buffer = im.as_rgba_str()
             _png.write_png(buffer, cols, rows, filename)
             im.flipud_out()
+            oid = oid or 'Im_' + self._make_id('image', filename)
             attrib['xlink:href'] = filename
 
+        attrib['id'] = oid
+        
         if transform is None:
             self.writer.element(
                 'image',

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -222,7 +222,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
     @allow_rasterization
     def draw(self, renderer):
         if not self.get_visible(): return
-        renderer.open_group(self.__class__.__name__)
+        renderer.open_group(self.__class__.__name__, self.get_gid())
 
         self.update_scalarmappable()
 
@@ -1264,7 +1264,7 @@ class QuadMesh(Collection):
     @allow_rasterization
     def draw(self, renderer):
         if not self.get_visible(): return
-        renderer.open_group(self.__class__.__name__)
+        renderer.open_group(self.__class__.__name__, self.get_gid())
         transform = self.get_transform()
         transOffset = self._transOffset
         offsets = self._offsets

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -322,7 +322,8 @@ class _AxesImageBase(martist.Artist, cm.ScalarMappable):
                                     # may be better solution -JJL
 
         im._url = self.get_url()
-
+        im._gid = self.get_gid()
+        
         renderer.draw_image(gc, xmin, ymin, im, dxintv, dyintv,
                             trans_ic_to_canvas)
 
@@ -356,6 +357,7 @@ class _AxesImageBase(martist.Artist, cm.ScalarMappable):
             if im is None:
                 return
             im._url = self.get_url()
+            im._gid = self.get_gid()
             renderer.draw_image(gc, l, b, im)
         gc.restore()
 


### PR DESCRIPTION
These are somewhat old fixes that resolve issues I had with setting gid to images and PathCollections. It also adds interactive svg examples, but these are still a bit crude and clunky.

I just realized that your commit putting clip-path defs at the end of the file causes an issue with chrome. These defs should appear before the clip-paths are used, otherwise these elements are simply not displayed. 
